### PR TITLE
[Build] Check C++ ABI and exception issues with Clang/GCC on Cygwin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+set(CMAKE_LEGACY_CYGWIN_WIN32 0)   # Prevent CMake showing a warning
+
 ##############################################################################
 # Setup project
 ##############################################################################
@@ -59,6 +61,19 @@ boost_hana_append_flag(BOOST_HANA_HAS_WALL                       -Wall)
 boost_hana_append_flag(BOOST_HANA_HAS_WEXTRA                     -Wextra)
 boost_hana_append_flag(BOOST_HANA_HAS_WNO_UNUSED_LOCAL_TYPEDEFS  -Wno-unused-local-typedefs)
 boost_hana_append_flag(BOOST_HANA_HAS_WWRITE_STRINGS             -Wwrite-strings)
+
+##############################################################################
+# Check for known compiler issues
+##############################################################################
+
+# Perform some basic checks on compiler id and version
+include(CheckCxxCompilerCompatibility)
+# Check for C++ exception handling, perform compilation check if
+# exceptions are enabled by the compiler. May fail on Cygwin etc.
+include(CheckCxxExceptions)
+# Check standard library type traits implementation,
+# a possible violation of C++14 of libstdc++ provided by GCC < 5.0.0
+include(CheckCxxTypeTraits)
 
 
 ##############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,13 +2,13 @@
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
-set(CMAKE_LEGACY_CYGWIN_WIN32 0)   # Prevent CMake showing a warning
+#set(CMAKE_LEGACY_CYGWIN_WIN32 0)   # Prevent CMake showing a warning
 
 ##############################################################################
 # Setup project
 ##############################################################################
-project(Boost.Hana CXX)
 cmake_minimum_required(VERSION 3.0)
+project(Boost.Hana CXX)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 enable_testing()
 

--- a/cmake/CheckCxxCompilerCompatibility.cmake
+++ b/cmake/CheckCxxCompilerCompatibility.cmake
@@ -1,4 +1,5 @@
 # Copyright Louis Dionne 2015
+# with contributions of Markus J. Weber 2015
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 #
@@ -61,4 +62,3 @@ if(SHOW_PREFERRED_COMPILER)
       ###
     ")
 endif()
-

--- a/cmake/CheckCxxCompilerCompatibility.cmake
+++ b/cmake/CheckCxxCompilerCompatibility.cmake
@@ -1,0 +1,64 @@
+# Copyright Louis Dionne 2015
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+#
+#
+# This CMake module checks the compiler and linker for compatibility and
+# provides hints to the user.
+
+if    (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+   if (${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS "3.5.0")
+      message(WARNING "
+      ###
+      ###   You appear to use Clang++ compiler version ${CMAKE_CXX_COMPILER_VERSION},
+      ###   which is most likely unable to compile Boost::Hana.
+      ###
+      ")
+      SET(SHOW_PREFERRED_COMPILER ON)
+    endif()
+elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+    SET(SHOW_PREFERRED_COMPILER ON)
+    if (${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS "5.1.0")
+      message("
+      ###
+      ###   You appear to use GNU C++ compiler version ${CMAKE_CXX_COMPILER_VERSION},
+      ###   which is known to be unable to compile Boost::Hana.
+      ###
+      ###   You should at least upgrade to version >= 5.1.0
+      ###
+      ")
+    else()
+      message("
+      ###
+      ###   You appear to use GNU C++ compiler version ${CMAKE_CXX_COMPILER_VERSION}.
+      ###
+      ###   The compatibility with Boost::Hana is not yet confirmed.
+      ###
+      ")
+    endif()
+else()
+      message("
+      ###
+      ###   NOTE: You appear to use a compiler that is not yet tested
+      ###         with Boost::Hana. Please tell us about whether it
+      ###         successfully compiles or if and how it failes.
+      ###
+      ###         Thanks !
+      ###
+      ")
+      SET(SHOW_PREFERRED_COMPILER ON)
+endif()
+
+if(SHOW_PREFERRED_COMPILER)
+    message("
+      ###
+      ###   ---   Consider switching to Clang >= 3.5.0   ---
+      ###
+      ###   If Clang is already installed on your system, then tell
+      ###   CMake about it by using
+      ###
+      ###     cmake -DCMAKE_CXX_COMPILER=clang++ ...
+      ###
+    ")
+endif()
+

--- a/cmake/CheckCxxExceptions.cmake
+++ b/cmake/CheckCxxExceptions.cmake
@@ -1,4 +1,5 @@
 # Copyright Louis Dionne 2015
+# with contributions of Markus J. Weber 2015
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 #
@@ -84,4 +85,3 @@ else()
     unset(CXX_EXCEPTIONS_COMPILE)
     unset(CXX_EXCEPTIONS_COMPILE_COMPILED)
 endif()
-

--- a/cmake/CheckCxxExceptions.cmake
+++ b/cmake/CheckCxxExceptions.cmake
@@ -1,0 +1,87 @@
+# Copyright Louis Dionne 2015
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+#
+#
+# This CMake module checks whether the compiler and linker supports C++
+# Exception Handling. This should catch two possible issues:
+#   1) The user provided a compiler or linker flag to deactivate exceptions,
+#      such as -fno-exceptions for GCC/Clang/Intel C++
+#   2) The linker fails due to some internal error with exceptions,
+#      which is at least a known issue for some Cygwin configurations using
+#      Clang.
+#
+# Approach: First the existence of the macro symbol __EXCEPTIONS is checked,
+# which is set if exceptions should be available. If available, then a
+# compilation check is pursued. If that fails, a message is produced and
+# exceptions are deactivated for the further process.
+#
+# If ultimately exceptions work, then the cmake variable is set:
+#    CXX_EXCEPTIONS_ENABLED = 1
+# if they are deactivated or didn't compile
+#    CXX_EXCEPTIONS_ENABLED = 0
+#
+# Furthermore, the compiler flag '-fno-exceptions' is automatically added if
+# the compilation check fails. Unfortunately a re-check is not performed since
+# CMake caches the test results.
+
+# ---------------------------------------------------------------------------
+
+# Check whether the compiler should support exceptions
+include(CheckCXXSymbolExists)
+CHECK_CXX_SYMBOL_EXISTS(__EXCEPTIONS "" CXX_EXCEPTIONS_ENABLED)
+
+if(NOT CXX_EXCEPTIONS_ENABLED)
+    message("-- C++ exceptions in compiler: DISABLED")
+else()
+    message("-- C++ exceptions in compiler: ENABLED")
+
+    # If exceptions are enabled, then the following code should compile and run
+    # successfully:
+    include(CheckCXXSourceRuns)
+    check_cxx_source_runs("
+        #include <iostream>
+        int dummy( int a ) { if (a <0) throw a; return a; };
+        int main () {
+            int a = 0;
+            try { a = dummy( -1 ); }
+            catch (int e) { std::cout << e << std::endl; }
+            std::cout << a << std::endl;
+            return 0;
+        }
+        " CXX_EXCEPTIONS_COMPILE)
+
+    # If exceptions are enabled, but don't compile, then try to disable them.
+    if (NOT CXX_EXCEPTIONS_COMPILE)
+
+        # Actually change the compiler flags
+        set(CMAKE_CXX_FLAGS "-fno-exceptions ${CMAKE_CXX_FLAGS}" )
+
+        message("
+    ### WARNING: Your C++ Compiler failed at compiling with exceptions.
+    ###
+    ### Boost::Hana is not depending on C++ exceptions, but some examples
+    ### might and perhaps your own code does as well.
+    ###
+    ### The build process will now proceed without exceptions by adding
+    ### the compiler flag '-fno-exceptions'. This should be sufficient
+    ### for most compilers for the present tests of Boost::Hana.
+    ")
+        if(CYGWIN AND (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"))
+        message(
+"    ### However, since you're running Cygwin, you might see a known problem
+    ### with Clang on Windows. You should then add the C++ compiler flag
+    ### '-fno-exceptions' also manually to your own code.
+    ")
+        endif()
+
+        # It seems we cannot simply repeat the check, thus we need to disable
+        # the exceptions manually...
+        set(CXX_EXCEPTIONS_ENABLED 0)
+        message("-- CXX compiler flag '-fno-exceptions' added.")
+    endif()
+    # Remove the temporary variables of the compilation check.
+    unset(CXX_EXCEPTIONS_COMPILE)
+    unset(CXX_EXCEPTIONS_COMPILE_COMPILED)
+endif()
+

--- a/cmake/CheckCxxTypeTraits.cmake
+++ b/cmake/CheckCxxTypeTraits.cmake
@@ -1,0 +1,65 @@
+# Copyright Louis Dionne 2015
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+#
+#
+# This CMake module checks the full implementation of the C++ standard library
+# by performing a compilation check. If anything goes wrong, most likely an
+# incomplete implementation of C++14 is used from GCC < 5.1.0.
+#
+# These checks include code in the file <type_traits>
+#    - the 'std::is_trivially_*' traits
+#    - the 'aligned_union' struct
+#
+# If an incomplete libstdc++ is detected, a CMake variable and macro symbol is set
+#    BOOST_HANA_CXX_INCOMPLETE_STDLIB = 1
+
+include(CheckCXXSourceRuns)
+check_cxx_source_runs("
+// Check whether the used C++ standard library implements trivially type traits
+#include <type_traits>
+#include <iostream>
+
+#define CHECK_TRAIT(METHOD)  \
+    if (METHOD::value) \
+        std::cout << #METHOD << std::endl;
+
+int main () {
+    // Check for a basic type trait. If this doesn't work, something weird is wrong.
+    CHECK_TRAIT(std::is_integral<int>)
+
+    CHECK_TRAIT(std::is_trivially_copyable<int>)
+    CHECK_TRAIT(std::is_trivially_constructible<int>)
+    CHECK_TRAIT(std::is_trivially_default_constructible<int>)
+    CHECK_TRAIT(std::is_trivially_copy_constructible<int>)
+    CHECK_TRAIT(std::is_trivially_move_constructible<int>)
+
+    if (std::is_trivially_assignable<int,int>::value) \
+        std::cout << \"std::is_trivially_assignable<int,int>\" << std::endl;
+    CHECK_TRAIT(std::is_trivially_copy_assignable<int>)
+    CHECK_TRAIT(std::is_trivially_move_assignable<int>)
+
+    CHECK_TRAIT(std::is_trivially_destructible<int>)
+
+    union U { int i; char c; double d; };
+    using au_t = std::aligned_union<sizeof(U),int,char,double>::type;
+
+    return 0;
+}
+" CXX_COMPLETE_STDLIBC14)
+
+if (NOT CXX_COMPLETE_STDLIBC14)
+    message("
+    ### Your C++ standard library has an incomplete implementation of 
+    ### the C++14 type traits in <type_traits>. The depending code is
+    ### automatically deactivated in Boost::Hana and all tests by
+    ### adding the definition -DBOOST_HANA_CXX_INCOMPLETE_STDLIB.
+    ")
+    set(BOOST_HANA_CXX_INCOMPLETE_STDLIB 1 CACHE BOOL
+        "An incomplete libstdc++ has been detected." FORCE)
+    add_definitions( -DBOOST_HANA_CXX_INCOMPLETE_STDLIB )
+endif()
+
+# Remove the temporary cmake variable to show this warning every time.
+unset(CXX_COMPLETE_STDLIBC14)
+

--- a/cmake/CheckCxxTypeTraits.cmake
+++ b/cmake/CheckCxxTypeTraits.cmake
@@ -16,6 +16,7 @@
 #    BOOST_HANA_CXX_INCOMPLETE_STDLIB = 1
 
 include(CheckCXXSourceRuns)
+set(CMAKE_REQUIRED_FLAGS "-std=c++14")
 check_cxx_source_runs("
 // Check whether the used C++ standard library implements trivially type traits
 #include <type_traits>
@@ -35,7 +36,7 @@ int main () {
     CHECK_TRAIT(std::is_trivially_copy_constructible<int>)
     CHECK_TRAIT(std::is_trivially_move_constructible<int>)
 
-    if (std::is_trivially_assignable<int,int>::value) \
+    if (std::is_trivially_assignable<int,int>::value)
         std::cout << \"std::is_trivially_assignable<int,int>\" << std::endl;
     CHECK_TRAIT(std::is_trivially_copy_assignable<int>)
     CHECK_TRAIT(std::is_trivially_move_assignable<int>)
@@ -62,4 +63,5 @@ if (NOT CXX_COMPLETE_STDLIBC14)
 endif()
 
 # Remove the temporary cmake variable to show this warning every time.
+unset(CMAKE_REQUIRED_FLAGS)
 unset(CXX_COMPLETE_STDLIBC14)

--- a/cmake/CheckCxxTypeTraits.cmake
+++ b/cmake/CheckCxxTypeTraits.cmake
@@ -1,4 +1,5 @@
 # Copyright Louis Dionne 2015
+# with contributions of Markus J. Weber 2015
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 #
@@ -50,7 +51,7 @@ int main () {
 
 if (NOT CXX_COMPLETE_STDLIBC14)
     message("
-    ### Your C++ standard library has an incomplete implementation of 
+    ### Your C++ standard library has an incomplete implementation of
     ### the C++14 type traits in <type_traits>. The depending code is
     ### automatically deactivated in Boost::Hana and all tests by
     ### adding the definition -DBOOST_HANA_CXX_INCOMPLETE_STDLIB.
@@ -62,4 +63,3 @@ endif()
 
 # Remove the temporary cmake variable to show this warning every time.
 unset(CXX_COMPLETE_STDLIBC14)
-

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -60,7 +60,6 @@ endif()
 if (CYGWIN)
     boost_hana_list_remove_glob(BOOST_HANA_EXAMPLE_SOURCES GLOB_RECURSE
         "ap.cpp"                                # constexpr error
-        #"functional/overload_linearly.cpp"      # uses exceptions
         "tutorial/introspection.json.cpp"       # no to_string in namespace std
         "wandbox.cpp"                           # no to_string in namespace std
     )

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -56,6 +56,17 @@ if (NOT Boost_FOUND)
     )
 endif()
 
+# The following examples seem to fail under Clang++ 3.5.2 on Cygwin
+if (CYGWIN)
+    boost_hana_list_remove_glob(BOOST_HANA_EXAMPLE_SOURCES GLOB_RECURSE
+        "ap.cpp"                                # constexpr error
+        #"functional/overload_linearly.cpp"      # uses exceptions
+        "tutorial/introspection.json.cpp"       # no to_string in namespace std
+        "wandbox.cpp"                           # no to_string in namespace std
+    )
+    message("The examples (ap, wandbox, and tutorial/introspection.json) are omitted on Cygwin.")
+endif()
+
 
 ##############################################################################
 # Setup the `wandbox` target, which uploads the whole library along with the

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -59,9 +59,12 @@ endif()
 # The following examples seem to fail under Clang++ 3.5.2 on Cygwin
 if (CYGWIN)
     boost_hana_list_remove_glob(BOOST_HANA_EXAMPLE_SOURCES GLOB_RECURSE
+    # A constexpr related error occurs
         "ap.cpp"                                # constexpr error
-        "tutorial/introspection.json.cpp"       # no to_string in namespace std
-        "wandbox.cpp"                           # no to_string in namespace std
+    # The following use std::tostring<> which is not available on Cygwin
+    # See https://cygwin.com/ml/cygwin/2015-01/msg00251.html
+        "tutorial/introspection.json.cpp"
+        "wandbox.cpp"
     )
     message("The examples (ap, wandbox, and tutorial/introspection.json) are omitted on Cygwin.")
 endif()

--- a/example/functional/overload_linearly.cpp
+++ b/example/functional/overload_linearly.cpp
@@ -4,6 +4,7 @@ Distributed under the Boost Software License, Version 1.0.
 (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
  */
 
+#include <cstdlib>
 #include <boost/hana/assert.hpp>
 #include <boost/hana/functional/overload_linearly.hpp>
 
@@ -14,7 +15,7 @@ namespace hana = boost::hana;
 auto f = hana::overload_linearly(
     [](int i) { return i + 1; },
     [](std::string s) { return s + "d"; },
-    [](double) { throw "never called"; }
+    [](double) { std::abort(); /* "never called"; */ }
 );
 
 int main() {

--- a/include/boost/hana.hpp
+++ b/include/boost/hana.hpp
@@ -11,6 +11,13 @@ Distributed under the Boost Software License, Version 1.0.
 #ifndef BOOST_HANA_HPP
 #define BOOST_HANA_HPP
 
+// Check the compiler for general C++14 capabilities
+#if (__cplusplus < 201400)
+#error "\
+Your compiler doesn't provide C++14 or higher capabilities. \
+Try adding the compiler flag '-std=c++14' or '-std=c++1y'."
+#endif
+
 //! @defgroup group-concepts Concepts
 //! Concepts provided by the library.
 

--- a/include/boost/hana/ext/std/type_traits.hpp
+++ b/include/boost/hana/ext/std/type_traits.hpp
@@ -53,7 +53,9 @@ namespace boost { namespace hana { namespace traits {
     constexpr auto is_const = trait<std::is_const>;
     constexpr auto is_volatile = trait<std::is_volatile>;
     constexpr auto is_trivial = trait<std::is_trivial>;
+#ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     constexpr auto is_trivially_copyable = trait<std::is_trivially_copyable>;
+#endif
     constexpr auto is_standard_layout = trait<std::is_standard_layout>;
     constexpr auto is_pod = trait<std::is_pod>;
     constexpr auto is_literal_type = trait<std::is_literal_type>;
@@ -65,31 +67,45 @@ namespace boost { namespace hana { namespace traits {
 
     // Supported operations
     constexpr auto is_constructible = trait<std::is_constructible>;
+#ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     constexpr auto is_trivially_constructible = trait<std::is_trivially_constructible>;
+#endif
     constexpr auto is_nothrow_constructible = trait<std::is_nothrow_constructible>;
 
     constexpr auto is_default_constructible = trait<std::is_default_constructible>;
+#ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     constexpr auto is_trivially_default_constructible = trait<std::is_trivially_default_constructible>;
+#endif
     constexpr auto is_nothrow_default_constructible = trait<std::is_nothrow_default_constructible>;
 
     constexpr auto is_copy_constructible = trait<std::is_copy_constructible>;
+#ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     constexpr auto is_trivially_copy_constructible = trait<std::is_trivially_copy_constructible>;
+#endif
     constexpr auto is_nothrow_copy_constructible = trait<std::is_nothrow_copy_constructible>;
 
     constexpr auto is_move_constructible = trait<std::is_move_constructible>;
+#ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     constexpr auto is_trivially_move_constructible = trait<std::is_trivially_move_constructible>;
+#endif
     constexpr auto is_nothrow_move_constructible = trait<std::is_nothrow_move_constructible>;
 
     constexpr auto is_assignable = trait<std::is_assignable>;
+#ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     constexpr auto is_trivially_assignable = trait<std::is_trivially_assignable>;
+#endif
     constexpr auto is_nothrow_assignable = trait<std::is_nothrow_assignable>;
 
     constexpr auto is_copy_assignable = trait<std::is_copy_assignable>;
+#ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     constexpr auto is_trivially_copy_assignable = trait<std::is_trivially_copy_assignable>;
+#endif
     constexpr auto is_nothrow_copy_assignable = trait<std::is_nothrow_copy_assignable>;
 
     constexpr auto is_move_assignable = trait<std::is_move_assignable>;
+#ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     constexpr auto is_trivially_move_assignable = trait<std::is_trivially_move_assignable>;
+#endif
     constexpr auto is_nothrow_move_assignable = trait<std::is_nothrow_move_assignable>;
 
     constexpr auto is_destructible = trait<std::is_destructible>;
@@ -168,6 +184,7 @@ namespace boost { namespace hana { namespace traits {
         }
     } aligned_storage{};
 
+#ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     constexpr struct aligned_union_t {
         template <typename Len, typename ...T>
         constexpr auto operator()(Len const&, T&&...) const {
@@ -178,6 +195,7 @@ namespace boost { namespace hana { namespace traits {
             return hana::type_c<Result>;
         }
     } aligned_union{};
+#endif
 
     constexpr auto decay = metafunction<std::decay>;
     // enable_if

--- a/include/boost/hana/ext/std/type_traits.hpp
+++ b/include/boost/hana/ext/std/type_traits.hpp
@@ -19,6 +19,22 @@ Distributed under the Boost Software License, Version 1.0.
 #include <cstddef>
 #include <type_traits>
 
+// Note: The C++ standard library of GCC < 5.1 is incomplete in that
+// it misses some of the std::is_triviall_y* functions and the struct
+// aligned_union. Hence, these are disabled when including a
+//     #define BOOST_HANA_CXX_INCOMPLETE_STDLIB
+// The problem may also occur with any version of Clang with is
+// configured to use the systems standard library, and if that
+// happens to be the incomplete one of GCC. Unfortunately, the
+// compiler doesn't tell which stdlib it uses, respectively Clang
+// just pretends to use a specific one. Hence the flag is required.
+// However, although GCC < 5.1.0 is definitly not able to compile
+// Boost::Hana, Clang is when using GCC >= 4.9.x; but some features
+// may still fail. See also github issue #167.
+//
+// TODO: A more Boost::Hana-like style might be a std::enable_if< >
+// solution that only applies if those traits are available...
+
 
 namespace boost { namespace hana { namespace traits {
     ///////////////////
@@ -53,9 +69,9 @@ namespace boost { namespace hana { namespace traits {
     constexpr auto is_const = trait<std::is_const>;
     constexpr auto is_volatile = trait<std::is_volatile>;
     constexpr auto is_trivial = trait<std::is_trivial>;
-#ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
+#  ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     constexpr auto is_trivially_copyable = trait<std::is_trivially_copyable>;
-#endif
+#  endif
     constexpr auto is_standard_layout = trait<std::is_standard_layout>;
     constexpr auto is_pod = trait<std::is_pod>;
     constexpr auto is_literal_type = trait<std::is_literal_type>;
@@ -67,45 +83,45 @@ namespace boost { namespace hana { namespace traits {
 
     // Supported operations
     constexpr auto is_constructible = trait<std::is_constructible>;
-#ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
+#  ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     constexpr auto is_trivially_constructible = trait<std::is_trivially_constructible>;
-#endif
+#  endif
     constexpr auto is_nothrow_constructible = trait<std::is_nothrow_constructible>;
 
     constexpr auto is_default_constructible = trait<std::is_default_constructible>;
-#ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
+#  ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     constexpr auto is_trivially_default_constructible = trait<std::is_trivially_default_constructible>;
-#endif
+#  endif
     constexpr auto is_nothrow_default_constructible = trait<std::is_nothrow_default_constructible>;
 
     constexpr auto is_copy_constructible = trait<std::is_copy_constructible>;
-#ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
+#  ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     constexpr auto is_trivially_copy_constructible = trait<std::is_trivially_copy_constructible>;
-#endif
+#  endif
     constexpr auto is_nothrow_copy_constructible = trait<std::is_nothrow_copy_constructible>;
 
     constexpr auto is_move_constructible = trait<std::is_move_constructible>;
-#ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
+#  ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     constexpr auto is_trivially_move_constructible = trait<std::is_trivially_move_constructible>;
-#endif
+#  endif
     constexpr auto is_nothrow_move_constructible = trait<std::is_nothrow_move_constructible>;
 
     constexpr auto is_assignable = trait<std::is_assignable>;
-#ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
+#  ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     constexpr auto is_trivially_assignable = trait<std::is_trivially_assignable>;
-#endif
+#  endif
     constexpr auto is_nothrow_assignable = trait<std::is_nothrow_assignable>;
 
     constexpr auto is_copy_assignable = trait<std::is_copy_assignable>;
-#ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
+#  ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     constexpr auto is_trivially_copy_assignable = trait<std::is_trivially_copy_assignable>;
-#endif
+#  endif
     constexpr auto is_nothrow_copy_assignable = trait<std::is_nothrow_copy_assignable>;
 
     constexpr auto is_move_assignable = trait<std::is_move_assignable>;
-#ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
+#  ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     constexpr auto is_trivially_move_assignable = trait<std::is_trivially_move_assignable>;
-#endif
+#  endif
     constexpr auto is_nothrow_move_assignable = trait<std::is_nothrow_move_assignable>;
 
     constexpr auto is_destructible = trait<std::is_destructible>;
@@ -184,7 +200,7 @@ namespace boost { namespace hana { namespace traits {
         }
     } aligned_storage{};
 
-#ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
+#  ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     constexpr struct aligned_union_t {
         template <typename Len, typename ...T>
         constexpr auto operator()(Len const&, T&&...) const {
@@ -195,7 +211,7 @@ namespace boost { namespace hana { namespace traits {
             return hana::type_c<Result>;
         }
     } aligned_union{};
-#endif
+#  endif
 
     constexpr auto decay = metafunction<std::decay>;
     // enable_if

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -130,6 +130,24 @@ add_executable(${github_75} EXCLUDE_FROM_ALL
 boost_hana_add_unit_test(${github_75} ${CMAKE_CURRENT_BINARY_DIR}/${github_75})
 
 
+
+##############################################################################
+# Remove tests failing under Cygwin (GitHub issue #167)
+##############################################################################
+# The following examples seem to fail under Clang++ 3.5.2 on Cygwin
+# The reason may be the incomplete libstdc++ of gcc.
+if (CYGWIN)
+    boost_hana_list_remove_glob(BOOST_HANA_TEST_SOURCES GLOB_RECURSE
+        "sandbox/array.cpp"
+        "sandbox/array.hpp"
+        "sandbox/function.cpp"
+        "sandbox/llist.cpp"
+        "sandbox/string.cpp"
+    )
+    message("The tests in sandbox (array, function, llist and string) are omitted on Cygwin.")
+endif()
+
+
 ##############################################################################
 # Add all the unit tests
 ##############################################################################

--- a/test/ext/std/type_traits.cpp
+++ b/test/ext/std/type_traits.cpp
@@ -53,7 +53,9 @@ int main() {
     hana::traits::is_const(s);
     hana::traits::is_volatile(s);
     hana::traits::is_trivial(s);
+#  ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     hana::traits::is_trivially_copyable(s);
+#  endif
     hana::traits::is_standard_layout(s);
     hana::traits::is_pod(s);
     hana::traits::is_literal_type(s);
@@ -65,31 +67,45 @@ int main() {
 
     // Supported operations
     hana::traits::is_constructible(s, s);
+#  ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     hana::traits::is_trivially_constructible(s, s);
+#  endif
     hana::traits::is_nothrow_constructible(s, s);
 
     hana::traits::is_default_constructible(s);
+#  ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     hana::traits::is_trivially_default_constructible(s);
+#  endif
     hana::traits::is_nothrow_default_constructible(s);
 
     hana::traits::is_copy_constructible(s);
+#  ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     hana::traits::is_trivially_copy_constructible(s);
+#  endif
     hana::traits::is_nothrow_copy_constructible(s);
 
     hana::traits::is_move_constructible(s);
+#  ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     hana::traits::is_trivially_move_constructible(s);
+#  endif
     hana::traits::is_nothrow_move_constructible(s);
 
     hana::traits::is_assignable(s, s);
+#  ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     hana::traits::is_trivially_assignable(s, s);
+#  endif
     hana::traits::is_nothrow_assignable(s, s);
 
     hana::traits::is_copy_assignable(s);
+#  ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     hana::traits::is_trivially_copy_assignable(s);
+#  endif
     hana::traits::is_nothrow_copy_assignable(s);
 
     hana::traits::is_move_assignable(s);
+#  ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     hana::traits::is_trivially_move_assignable(s);
+#  endif
     hana::traits::is_nothrow_move_assignable(s);
 
     hana::traits::is_destructible(s);
@@ -141,7 +157,9 @@ int main() {
     // Miscellaneous transformations
     hana::traits::aligned_storage(hana::size_t<1>);
     hana::traits::aligned_storage(hana::size_t<1>, hana::size_t<1>);
+#  ifndef BOOST_HANA_CXX_INCOMPLETE_STDLIB
     hana::traits::aligned_union(hana::size_t<0>, s);
+#  endif
     hana::traits::decay(s);
 
     hana::traits::common_type(s, s);

--- a/test/numeric/main.hpp
+++ b/test/numeric/main.hpp
@@ -4,6 +4,13 @@ Distributed under the Boost Software License, Version 1.0.
 (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
  */
 
+#ifdef __EXCEPTIONS
+#  define THROW_OR_ABORT throw
+#else
+#include <cstdlib>
+#  define THROW_OR_ABORT std::abort()
+#endif
+
 #include <boost/hana.hpp>
 
 #include <test/numeric.hpp>
@@ -27,7 +34,7 @@ using namespace boost::hana;
 
 struct invalid {
     template <typename T>
-    operator T const() { throw; }
+    operator T const() { THROW_OR_ABORT; }
 };
 
 int main() {

--- a/test/sandbox/llist.cpp
+++ b/test/sandbox/llist.cpp
@@ -4,6 +4,13 @@ Distributed under the Boost Software License, Version 1.0.
 (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
  */
 
+#ifdef __EXCEPTIONS
+#  define THROW_OR_ABORT throw
+#else
+#include <cstdlib>
+#  define THROW_OR_ABORT std::abort()
+#endif
+
 #include <boost/hana.hpp>
 
 #include <cstddef>
@@ -37,13 +44,15 @@ struct llist {
 
     friend constexpr T head(llist self) {
         if (is_empty(self))
-            throw "head on empty list";
+            //throw "head on empty list";
+            THROW_OR_ABORT;
         return self.storage_.it_.head_;
     }
 
     friend constexpr llist tail(llist self) {
         if (is_empty(self))
-            throw "tail on empty list";
+            //throw "tail on empty list";
+            THROW_OR_ABORT;
         return *self.storage_.it_.next_;
     }
 


### PR DESCRIPTION
Fixes  #167

- Check whether compiler supports and successfully compiles with exceptions.
- Check whether the provided stdlib has C++14 type traits fully implemented.
- Perform some compiler version checks in cmake and give hints to the user.

Both errors occured on Cygwin using Clang 3.5.2 with libstdc++ from GCC
4.9.3. However, Clang may also use the GCC stdlib on other systems, like
Linux Mint.
The error with exceptions is also expected to occure on MSYS2 and maybe
Windows, since Clang seems to have general problems there.

Unfortunately, the incomplete stdlib is supposedly not detectable from within
the compilation. Thus a test is created which may fail during compilation.
If so, an additional symbol is defined to handle the issue:
BOOST_HANA_CXX_INCOMPLETE_STDLIB

Availability of exceptions is tested with the existance of __EXCEPTIONS, and
handled accordingly. Instead of throw, a assert(false) or abort() comes to mind.

Lastly, the cmake cygwin warning message is deactivated in CMakeLists.txt,
and the main include <boost/hana/hana.hpp> checks the C++ standard to be
at least C++14 or raises an error otherwise. Should give beginners a valuable
hint on what is going wrong...

A side note for other Cygwin/MinGW/MSYS2 users: Compile with Clang or
GCC with static binding of (both) standard libs using 
     -static-libgcc -static-libstdc++
Makes your life a lot easier.

Remaining issues are some non-compiling tests and examples. These have been
removed from the build on Cygwin. The reason may also be the incomplete stlib.
See test/CMakeLists.txt and example/CMakeLists.txt

Tested on
- Cygwin/Clang 3.5.2/libstdc++ of gcc 4.9.3 w/o exceptions (success)
- Cygwin/Clang 3.5.2/libstdc++ of gcc 4.9.3 w/ exceptions (failure, but captured)
- Cygwin/GCC 4.9.3/libstdc++ of gcc 4.9.3 (failure, as expected)
- Linux Mint/Clang 3.6.0/libstdc++ of gcc 4.8.4 (failure, as expected)
- Linux Mint/Clang 3.6.0/libc++ of clang 3.6.0 w/ exceptions (success)
- Linux Mint/gcc 4.8.4/libstdc++ of gcc 4.8.4 (uncaptured failure, as expected)